### PR TITLE
Replace the `--validate-wrapper-installation` call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN git clone https://github.com/mergermarket/cdflow /tmp/cdflow && \
     pip3 install -r /tmp/cdflow/requirements.txt && \
     cp /tmp/cdflow/cdflow.py /usr/local/bin/cdflow && \
     rm -rf /tmp/cdflow && \
-    cdflow --validate-wrapper-installation
+    python -c 'from importlib.util import spec_from_loader, module_from_spec; from importlib.machinery import SourceFileLoader; spec = spec_from_loader("cdflow", SourceFileLoader("cdflow", "/usr/local/bin/cdflow")); spec.loader.exec_module(module_from_spec(spec))'
 
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN git clone https://github.com/mergermarket/cdflow /tmp/cdflow && \
     pip3 install -r /tmp/cdflow/requirements.txt && \
     cp /tmp/cdflow/cdflow.py /usr/local/bin/cdflow && \
     rm -rf /tmp/cdflow && \
-    python -c 'from importlib.util import spec_from_loader, module_from_spec; from importlib.machinery import SourceFileLoader; spec = spec_from_loader("cdflow", SourceFileLoader("cdflow", "/usr/local/bin/cdflow")); spec.loader.exec_module(module_from_spec(spec))'
+    python -c 'from importlib.util import spec_from_loader, module_from_spec; \
+from importlib.machinery import SourceFileLoader; \
+spec = spec_from_loader("cdflow", SourceFileLoader("cdflow", "/usr/local/bin/cdflow")); \
+spec.loader.exec_module(module_from_spec(spec))'
 
 WORKDIR /workspace


### PR DESCRIPTION
Use `importlib` to import and run the `cdflow` module - it's a bit lengthy because it doesn't have a `.py` extension and the `imp` module was deprecated.

Technique from StackOverflow:
https://stackoverflow.com/questions/2601047/import-a-python-module-without-the-py-extension/43602645#43602645