### PR TITLE
Find and install the latest release of cdflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,7 @@ RUN apk add --no-cache git curl bash \
 
 RUN pip3 install -U awscli docker-compose
 
-RUN git clone https://github.com/mergermarket/cdflow /tmp/cdflow && \
-    pip3 install -r /tmp/cdflow/requirements.txt && \
-    cp /tmp/cdflow/cdflow.py /usr/local/bin/cdflow && \
-    rm -rf /tmp/cdflow && \
-    python -c 'from importlib.util import spec_from_loader, module_from_spec; \
-from importlib.machinery import SourceFileLoader; \
-spec = spec_from_loader("cdflow", SourceFileLoader("cdflow", "/usr/local/bin/cdflow")); \
-spec.loader.exec_module(module_from_spec(spec))'
+RUN curl -L "https://github.com/mergermarket/cdflow/releases/download/$(python -c "from urllib.request import urlopen; import json; print(json.loads(urlopen('https://api.github.com/repos/mergermarket/cdflow/releases/latest').read())['tag_name'])")/cdflow-Linux-x86_64" -o /usr/local/bin/cdflow && \
+    chmod +x /usr/local/bin/cdflow
 
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Docker container for running [cdflow](https://mergermarket.github.io/cdflow/) wi
 
 Run container with Docker-in-Docker:
 ```
-docker run -d --rm --privileged --name build -v $PWD:$PWD -w $PWD mergermarket/cdflow-builder
+docker container run -d --rm --privileged --name build -v $(pwd):$(pwd) -w $(pwd) mergermarket/cdflow-builder
 ```
 
 Run `cdflow` in the container:
 ```
-docker exec -t build cdflow --help
+docker container exec -t build cdflow --help
 ```


### PR DESCRIPTION
Read the tag name from the latest release on GitHub and interpolate that into the download URL. Quite long because an environment variable didn't seem to work in the `Dockerfile`

Update the readme with more recent `docker` commands and the `pwd` program instead of the environment variable.